### PR TITLE
Include math header for linux

### DIFF
--- a/zfmagfldSup/zfmagfld_impl.cpp
+++ b/zfmagfldSup/zfmagfld_impl.cpp
@@ -10,7 +10,7 @@
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_errno.h>
-#include <math.h>
+#include <cmath>
 
 #include <string>
 #include <vector>

--- a/zfmagfldSup/zfmagfld_impl.cpp
+++ b/zfmagfldSup/zfmagfld_impl.cpp
@@ -10,6 +10,7 @@
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_errno.h>
+#include <math.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Fixes linux build, as `sqrt` is not available by default on linux