### PR TITLE
Remove spurious alarm

### DIFF
--- a/zfmagfldSup/zfmagfld.db
+++ b/zfmagfldSup/zfmagfld.db
@@ -23,7 +23,6 @@ record(aSub, "$(P)CORRECTFIELD") {
   field(SCAN, "Passive")
 
   field(FLNK, "$(SQNCR)")
-  info(alarm, "ZFMAGFLD")
 
   # Offset-shifted data from magnetometer
   field(INPA, "$(P)APPLYOFFSET:X MS")

--- a/zfmagfldSup/zfmagfld_cdaq_data.template
+++ b/zfmagfldSup/zfmagfld_cdaq_data.template
@@ -10,7 +10,9 @@ record(ai, "$(P)DAQ:$(AXIS)")
   field(ADEL, 0.1)
   info(archive, "VAL")
   field(SDIS, "$(P)DISABLE")
-  }
+  
+  info(alarm, "ZFMAGFLD")
+}
 
 record(ai, "$(P)DAQ:$(AXIS):_RAW")
 {


### PR DESCRIPTION
Remove spurious alarm, it alarms based on `VAL` but this is largely meaningless for an `aSub` record and was causing a persistent alarm in EMU's alarm view even when the zero field system is working correctly.