### PR TITLE
Ticket8379 second zfmagfld ioc

### DIFF
--- a/zfmagfldSup/zfmagfld.db
+++ b/zfmagfldSup/zfmagfld.db
@@ -123,9 +123,9 @@ record(ai, "$(P)RANGE"){
   field(PINI, "YES")
 }
 
-$(IFFORCED_SCAN) alias("$(P)DAQ:X", "$(P)TAKEDATA")
+$(IFNOTFORCED_SCAN) alias("$(P)DAQ:X", "$(P)TAKEDATA")
 
-$(IFNOTFORCED_SCAN) record(ao, "$(P)TAKEDATA"){
-$(IFNOTFORCED_SCAN)   field(DESC, "Record which forces scans")
-$(IFNOTFORCED_SCAN)   field(SCAN, ".5 second")
-$(IFNOTFORCED_SCAN)   field(FLNK, "$(P)DAQ:X") }
+$(IFFORCED_SCAN) record(ao, "$(P)TAKEDATA"){
+$(IFFORCED_SCAN)   field(DESC, "Record which forces scans")
+$(IFFORCED_SCAN)   field(SCAN, ".5 second")
+$(IFFORCED_SCAN)   field(FLNK, "$(P)DAQ:X") }

--- a/zfmagfldSup/zfmagfld.db
+++ b/zfmagfldSup/zfmagfld.db
@@ -123,4 +123,9 @@ record(ai, "$(P)RANGE"){
   field(PINI, "YES")
 }
 
-alias("$(P)DAQ:X", "$(P)TAKEDATA")
+$(IFFORCED_SCAN) alias("$(P)DAQ:X", "$(P)TAKEDATA")
+
+$(IFNOTFORCED_SCAN) record(ao, "$(P)TAKEDATA"){
+$(IFNOTFORCED_SCAN)   field(DESC, "Record which forces scans")
+$(IFNOTFORCED_SCAN)   field(SCAN, ".5 second")
+$(IFNOTFORCED_SCAN)   field(FLNK, "$(P)DAQ:X") }

--- a/zfmagfldSup/zfmagfld_sensor_matrix.template
+++ b/zfmagfldSup/zfmagfld_sensor_matrix.template
@@ -1,7 +1,7 @@
 record(ai, "$(P)SENSORMATRIX:$(ROW)$(COLUMN)") {
   field(DESC, "Element $(ROW), $(COLUMN) of sensor matrix")
   field(DTYP, "Soft Channel")
-  
+  field(VAL, "$(MATRIX_$(ROW)$(COLUMN))")
   field(EGU, "")
   field(PREC, "2")
   field(PINI, "YES")


### PR DESCRIPTION
###Description of work

Allows use of a new macro to toggle whether we want to automatically scan inputs, or to only scan them when requested by another IOC (zfcntrl)

### To test

[Ticket 8379](https://github.com/ISISComputingGroup/IBEX/issues/8379)

### Acceptance criteria

2nd IOC runs when booted. Additionally, new IocTestFramework tests pass.